### PR TITLE
Improve goroutine efficiency

### DIFF
--- a/image.go
+++ b/image.go
@@ -3,6 +3,8 @@ package imagetk
 import (
 	"fmt"
 	"reflect"
+	"runtime"
+	"sync"
 )
 
 const (
@@ -219,156 +221,284 @@ func GetImageFromArray(data any) (*Image, error) {
 }
 
 func GetArrayFromImage(img *Image) (any, error) {
-	numPixels := img.NumPixels()
+	numGoroutines := uint64(runtime.NumCPU())
+	chunkSize := uint64(img.NumPixels()) / numGoroutines
+	if chunkSize*numGoroutines < uint64(img.NumPixels()) {
+		chunkSize += 1
+		if numGoroutines > uint64(img.NumPixels()) {
+			numGoroutines = uint64(img.NumPixels())
+		}
+	}
+	wg := sync.WaitGroup{}
 	switch img.pixelType {
 	case PixelTypeUInt8:
-		data := make([]uint8, numPixels)
-		for i := uint64(0); i < numPixels; i++ {
-			index, err := img.GetIndexFromLinearIndex(i)
-			if err != nil {
-				return nil, err
+		data := make([]uint8, img.NumPixels())
+		for chunk := uint64(0); chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > img.NumPixels() {
+				end = img.NumPixels()
 			}
-			value, err := img.GetPixelAsUInt8(index)
-			if err != nil {
-				return nil, err
-			}
-			data[i] = value
+			wg.Add(1)
+			go func(start, end uint64) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					index, err := img.GetIndexFromLinearIndex(i)
+					if err != nil {
+						return
+					}
+					value, err := img.GetPixelAsUInt8(index)
+					if err != nil {
+						return
+					}
+					data[i] = value
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		shapedData := reshape(data, img.size)
 		return shapedData, nil
 	case PixelTypeInt8:
-		data := make([]int8, numPixels)
-		for i := uint64(0); i < numPixels; i++ {
-			index, err := img.GetIndexFromLinearIndex(i)
-			if err != nil {
-				return nil, err
+		data := make([]int8, img.NumPixels())
+		for chunk := uint64(0); chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > img.NumPixels() {
+				end = img.NumPixels()
 			}
-			value, err := img.GetPixelAsInt8(index)
-			if err != nil {
-				return nil, err
-			}
-			data[i] = value
+			wg.Add(1)
+			go func(start, end uint64) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					index, err := img.GetIndexFromLinearIndex(i)
+					if err != nil {
+						return
+					}
+					value, err := img.GetPixelAsInt8(index)
+					if err != nil {
+						return
+					}
+					data[i] = value
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		shapedData := reshape(data, img.size)
 		return shapedData, nil
 	case PixelTypeUInt16:
-		data := make([]uint16, numPixels)
-		for i := uint64(0); i < numPixels; i++ {
-			index, err := img.GetIndexFromLinearIndex(i)
-			if err != nil {
-				return nil, err
+		data := make([]uint16, img.NumPixels())
+		for chunk := uint64(0); chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > img.NumPixels() {
+				end = img.NumPixels()
 			}
-			value, err := img.GetPixelAsUInt16(index)
-			if err != nil {
-				return nil, err
-			}
-			data[i] = value
+			wg.Add(1)
+			go func(start, end uint64) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					index, err := img.GetIndexFromLinearIndex(i)
+					if err != nil {
+						return
+					}
+					value, err := img.GetPixelAsUInt16(index)
+					if err != nil {
+						return
+					}
+					data[i] = value
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		shapedData := reshape(data, img.size)
 		return shapedData, nil
 	case PixelTypeInt16:
-		data := make([]int16, numPixels)
-		for i := uint64(0); i < numPixels; i++ {
-			index, err := img.GetIndexFromLinearIndex(i)
-			if err != nil {
-				return nil, err
+		data := make([]int16, img.NumPixels())
+		for chunk := uint64(0); chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > img.NumPixels() {
+				end = img.NumPixels()
 			}
-			value, err := img.GetPixelAsInt16(index)
-			if err != nil {
-				return nil, err
-			}
-			data[i] = value
+			wg.Add(1)
+			go func(start, end uint64) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					index, err := img.GetIndexFromLinearIndex(i)
+					if err != nil {
+						return
+					}
+					value, err := img.GetPixelAsInt16(index)
+					if err != nil {
+						return
+					}
+					data[i] = value
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		shapedData := reshape(data, img.size)
 		return shapedData, nil
 	case PixelTypeUInt32:
-		data := make([]uint32, numPixels)
-		for i := uint64(0); i < numPixels; i++ {
-			index, err := img.GetIndexFromLinearIndex(i)
-			if err != nil {
-				return nil, err
+		data := make([]uint32, img.NumPixels())
+		for chunk := uint64(0); chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > img.NumPixels() {
+				end = img.NumPixels()
 			}
-			value, err := img.GetPixelAsUInt32(index)
-			if err != nil {
-				return nil, err
-			}
-			data[i] = value
+			wg.Add(1)
+			go func(start, end uint64) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					index, err := img.GetIndexFromLinearIndex(i)
+					if err != nil {
+						return
+					}
+					value, err := img.GetPixelAsUInt32(index)
+					if err != nil {
+						return
+					}
+					data[i] = value
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		shapedData := reshape(data, img.size)
 		return shapedData, nil
 	case PixelTypeInt32:
-		data := make([]int32, numPixels)
-		for i := uint64(0); i < numPixels; i++ {
-			index, err := img.GetIndexFromLinearIndex(i)
-			if err != nil {
-				return nil, err
+		data := make([]int32, img.NumPixels())
+		for chunk := uint64(0); chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > img.NumPixels() {
+				end = img.NumPixels()
 			}
-			value, err := img.GetPixelAsInt32(index)
-			if err != nil {
-				return nil, err
-			}
-			data[i] = value
+			wg.Add(1)
+			go func(start, end uint64) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					index, err := img.GetIndexFromLinearIndex(i)
+					if err != nil {
+						return
+					}
+					value, err := img.GetPixelAsInt32(index)
+					if err != nil {
+						return
+					}
+					data[i] = value
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		shapedData := reshape(data, img.size)
 		return shapedData, nil
 	case PixelTypeUInt64:
-		data := make([]uint64, numPixels)
-		for i := uint64(0); i < numPixels; i++ {
-			index, err := img.GetIndexFromLinearIndex(i)
-			if err != nil {
-				return nil, err
+		data := make([]uint64, img.NumPixels())
+		for chunk := uint64(0); chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > img.NumPixels() {
+				end = img.NumPixels()
 			}
-			value, err := img.GetPixelAsUInt64(index)
-			if err != nil {
-				return nil, err
-			}
-			data[i] = value
+			wg.Add(1)
+			go func(start, end uint64) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					index, err := img.GetIndexFromLinearIndex(i)
+					if err != nil {
+						return
+					}
+					value, err := img.GetPixelAsUInt64(index)
+					if err != nil {
+						return
+					}
+					data[i] = value
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		shapedData := reshape(data, img.size)
 		return shapedData, nil
 	case PixelTypeInt64:
-		data := make([]int64, numPixels)
-		for i := uint64(0); i < numPixels; i++ {
-			index, err := img.GetIndexFromLinearIndex(i)
-			if err != nil {
-				return nil, err
+		data := make([]int64, img.NumPixels())
+		for chunk := uint64(0); chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > img.NumPixels() {
+				end = img.NumPixels()
 			}
-			value, err := img.GetPixelAsInt64(index)
-			if err != nil {
-				return nil, err
-			}
-			data[i] = value
+			wg.Add(1)
+			go func(start, end uint64) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					index, err := img.GetIndexFromLinearIndex(i)
+					if err != nil {
+						return
+					}
+					value, err := img.GetPixelAsInt64(index)
+					if err != nil {
+						return
+					}
+					data[i] = value
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		shapedData := reshape(data, img.size)
 		return shapedData, nil
 	case PixelTypeFloat32:
-		data := make([]float32, numPixels)
-		for i := uint64(0); i < numPixels; i++ {
-			index, err := img.GetIndexFromLinearIndex(i)
-			if err != nil {
-				return nil, err
+		data := make([]float32, img.NumPixels())
+		for chunk := uint64(0); chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > img.NumPixels() {
+				end = img.NumPixels()
 			}
-			value, err := img.GetPixelAsFloat32(index)
-			if err != nil {
-				return nil, err
-			}
-			data[i] = value
+			wg.Add(1)
+			go func(start, end uint64) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					index, err := img.GetIndexFromLinearIndex(i)
+					if err != nil {
+						return
+					}
+					value, err := img.GetPixelAsFloat32(index)
+					if err != nil {
+						return
+					}
+					data[i] = value
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		shapedData := reshape(data, img.size)
 		return shapedData, nil
 	case PixelTypeFloat64:
-		data := make([]float64, numPixels)
-		for i := uint64(0); i < numPixels; i++ {
-			index, err := img.GetIndexFromLinearIndex(i)
-			if err != nil {
-				return nil, err
+		data := make([]float64, img.NumPixels())
+		for chunk := uint64(0); chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > img.NumPixels() {
+				end = img.NumPixels()
 			}
-			value, err := img.GetPixelAsFloat64(index)
-			if err != nil {
-				return nil, err
-			}
-			data[i] = value
+			wg.Add(1)
+			go func(start, end uint64) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					index, err := img.GetIndexFromLinearIndex(i)
+					if err != nil {
+						return
+					}
+					value, err := img.GetPixelAsFloat64(index)
+					if err != nil {
+						return
+					}
+					data[i] = value
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		shapedData := reshape(data, img.size)
 		return shapedData, nil
 	default:
@@ -839,256 +969,385 @@ func (img *Image) AsType(pixelType int) (*Image, error) {
 		numPixels *= int(s)
 	}
 
+	numGoroutines := runtime.NumCPU()
+	chunkSize := numPixels / numGoroutines
+	if chunkSize*numGoroutines < numPixels {
+		chunkSize += 1
+		if numGoroutines > numPixels {
+			numGoroutines = numPixels
+		}
+	}
+	wg := sync.WaitGroup{}
 	switch pixelType {
 	case PixelTypeUInt8:
 		newPixelData := make([]uint8, numPixels)
-		for i := 0; i < numPixels; i++ {
-			switch img.pixelType {
-			case PixelTypeInt8:
-				newPixelData[i] = uint8(img.pixels.([]int8)[i])
-			case PixelTypeUInt16:
-				newPixelData[i] = uint8(img.pixels.([]uint16)[i])
-			case PixelTypeInt16:
-				newPixelData[i] = uint8(img.pixels.([]int16)[i])
-			case PixelTypeUInt32:
-				newPixelData[i] = uint8(img.pixels.([]uint32)[i])
-			case PixelTypeInt32:
-				newPixelData[i] = uint8(img.pixels.([]int32)[i])
-			case PixelTypeUInt64:
-				newPixelData[i] = uint8(img.pixels.([]uint64)[i])
-			case PixelTypeInt64:
-				newPixelData[i] = uint8(img.pixels.([]int64)[i])
-			case PixelTypeFloat32:
-				newPixelData[i] = uint8(img.pixels.([]float32)[i])
-			case PixelTypeFloat64:
-				newPixelData[i] = uint8(img.pixels.([]float64)[i])
+		for chunk := 0; chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > numPixels {
+				end = numPixels
 			}
+			wg.Add(1)
+			go func(start, end int) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					switch img.pixelType {
+					case PixelTypeInt8:
+						newPixelData[i] = uint8(img.pixels.([]int8)[i])
+					case PixelTypeUInt16:
+						newPixelData[i] = uint8(img.pixels.([]uint16)[i])
+					case PixelTypeInt16:
+						newPixelData[i] = uint8(img.pixels.([]int16)[i])
+					case PixelTypeUInt32:
+						newPixelData[i] = uint8(img.pixels.([]uint32)[i])
+					case PixelTypeInt32:
+						newPixelData[i] = uint8(img.pixels.([]int32)[i])
+					case PixelTypeUInt64:
+						newPixelData[i] = uint8(img.pixels.([]uint64)[i])
+					case PixelTypeInt64:
+						newPixelData[i] = uint8(img.pixels.([]int64)[i])
+					case PixelTypeFloat32:
+						newPixelData[i] = uint8(img.pixels.([]float32)[i])
+					case PixelTypeFloat64:
+						newPixelData[i] = uint8(img.pixels.([]float64)[i])
+					}
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		newImg.pixels = newPixelData
 	case PixelTypeInt8:
 		newPixelData := make([]int8, numPixels)
-		for i := 0; i < numPixels; i++ {
-			switch img.pixelType {
-			case PixelTypeUInt8:
-				newPixelData[i] = int8(img.pixels.([]uint8)[i])
-			case PixelTypeUInt16:
-				newPixelData[i] = int8(img.pixels.([]uint16)[i])
-			case PixelTypeInt16:
-				newPixelData[i] = int8(img.pixels.([]int16)[i])
-			case PixelTypeUInt32:
-				newPixelData[i] = int8(img.pixels.([]uint32)[i])
-			case PixelTypeInt32:
-				newPixelData[i] = int8(img.pixels.([]int32)[i])
-			case PixelTypeUInt64:
-				newPixelData[i] = int8(img.pixels.([]uint64)[i])
-			case PixelTypeInt64:
-				newPixelData[i] = int8(img.pixels.([]int64)[i])
-			case PixelTypeFloat32:
-				newPixelData[i] = int8(img.pixels.([]float32)[i])
-			case PixelTypeFloat64:
-				newPixelData[i] = int8(img.pixels.([]float64)[i])
+		for chunk := 0; chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > numPixels {
+				end = numPixels
 			}
+			wg.Add(1)
+			go func(start, end int) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					switch img.pixelType {
+					case PixelTypeUInt8:
+						newPixelData[i] = int8(img.pixels.([]uint8)[i])
+					case PixelTypeUInt16:
+						newPixelData[i] = int8(img.pixels.([]uint16)[i])
+					case PixelTypeInt16:
+						newPixelData[i] = int8(img.pixels.([]int16)[i])
+					case PixelTypeUInt32:
+						newPixelData[i] = int8(img.pixels.([]uint32)[i])
+					case PixelTypeInt32:
+						newPixelData[i] = int8(img.pixels.([]int32)[i])
+					case PixelTypeUInt64:
+						newPixelData[i] = int8(img.pixels.([]uint64)[i])
+					case PixelTypeInt64:
+						newPixelData[i] = int8(img.pixels.([]int64)[i])
+					case PixelTypeFloat32:
+						newPixelData[i] = int8(img.pixels.([]float32)[i])
+					case PixelTypeFloat64:
+						newPixelData[i] = int8(img.pixels.([]float64)[i])
+					}
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		newImg.pixels = newPixelData
 	case PixelTypeUInt16:
 		newPixelData := make([]uint16, numPixels)
-		for i := 0; i < numPixels; i++ {
-			switch img.pixelType {
-			case PixelTypeUInt8:
-				newPixelData[i] = uint16(img.pixels.([]uint8)[i])
-			case PixelTypeInt8:
-				newPixelData[i] = uint16(img.pixels.([]int8)[i])
-			case PixelTypeInt16:
-				newPixelData[i] = uint16(img.pixels.([]int16)[i])
-			case PixelTypeUInt32:
-				newPixelData[i] = uint16(img.pixels.([]uint32)[i])
-			case PixelTypeInt32:
-				newPixelData[i] = uint16(img.pixels.([]int32)[i])
-			case PixelTypeUInt64:
-				newPixelData[i] = uint16(img.pixels.([]uint64)[i])
-			case PixelTypeInt64:
-				newPixelData[i] = uint16(img.pixels.([]int64)[i])
-			case PixelTypeFloat32:
-				newPixelData[i] = uint16(img.pixels.([]float32)[i])
-			case PixelTypeFloat64:
-				newPixelData[i] = uint16(img.pixels.([]float64)[i])
+		for chunk := 0; chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > numPixels {
+				end = numPixels
 			}
+			wg.Add(1)
+			go func(start, end int) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					switch img.pixelType {
+					case PixelTypeUInt8:
+						newPixelData[i] = uint16(img.pixels.([]uint8)[i])
+					case PixelTypeInt8:
+						newPixelData[i] = uint16(img.pixels.([]int8)[i])
+					case PixelTypeInt16:
+						newPixelData[i] = uint16(img.pixels.([]int16)[i])
+					case PixelTypeUInt32:
+						newPixelData[i] = uint16(img.pixels.([]uint32)[i])
+					case PixelTypeInt32:
+						newPixelData[i] = uint16(img.pixels.([]int32)[i])
+					case PixelTypeUInt64:
+						newPixelData[i] = uint16(img.pixels.([]uint64)[i])
+					case PixelTypeInt64:
+						newPixelData[i] = uint16(img.pixels.([]int64)[i])
+					case PixelTypeFloat32:
+						newPixelData[i] = uint16(img.pixels.([]float32)[i])
+					case PixelTypeFloat64:
+						newPixelData[i] = uint16(img.pixels.([]float64)[i])
+					}
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		newImg.pixels = newPixelData
 	case PixelTypeInt16:
 		newPixelData := make([]int16, numPixels)
-		for i := 0; i < numPixels; i++ {
-			switch img.pixelType {
-			case PixelTypeUInt8:
-				newPixelData[i] = int16(img.pixels.([]uint8)[i])
-			case PixelTypeInt8:
-				newPixelData[i] = int16(img.pixels.([]int8)[i])
-			case PixelTypeUInt16:
-				newPixelData[i] = int16(img.pixels.([]uint16)[i])
-			case PixelTypeUInt32:
-				newPixelData[i] = int16(img.pixels.([]uint32)[i])
-			case PixelTypeInt32:
-				newPixelData[i] = int16(img.pixels.([]int32)[i])
-			case PixelTypeUInt64:
-				newPixelData[i] = int16(img.pixels.([]uint64)[i])
-			case PixelTypeInt64:
-				newPixelData[i] = int16(img.pixels.([]int64)[i])
-			case PixelTypeFloat32:
-				newPixelData[i] = int16(img.pixels.([]float32)[i])
-			case PixelTypeFloat64:
-				newPixelData[i] = int16(img.pixels.([]float64)[i])
+		for chunk := 0; chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > numPixels {
+				end = numPixels
 			}
+			wg.Add(1)
+			go func(start, end int) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					switch img.pixelType {
+					case PixelTypeUInt8:
+						newPixelData[i] = int16(img.pixels.([]uint8)[i])
+					case PixelTypeInt8:
+						newPixelData[i] = int16(img.pixels.([]int8)[i])
+					case PixelTypeUInt16:
+						newPixelData[i] = int16(img.pixels.([]uint16)[i])
+					case PixelTypeUInt32:
+						newPixelData[i] = int16(img.pixels.([]uint32)[i])
+					case PixelTypeInt32:
+						newPixelData[i] = int16(img.pixels.([]int32)[i])
+					case PixelTypeUInt64:
+						newPixelData[i] = int16(img.pixels.([]uint64)[i])
+					case PixelTypeInt64:
+						newPixelData[i] = int16(img.pixels.([]int64)[i])
+					case PixelTypeFloat32:
+						newPixelData[i] = int16(img.pixels.([]float32)[i])
+					case PixelTypeFloat64:
+						newPixelData[i] = int16(img.pixels.([]float64)[i])
+					}
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		newImg.pixels = newPixelData
 	case PixelTypeUInt32:
 		newPixelData := make([]uint32, numPixels)
-		for i := 0; i < numPixels; i++ {
-			switch img.pixelType {
-			case PixelTypeUInt8:
-				newPixelData[i] = uint32(img.pixels.([]uint8)[i])
-			case PixelTypeInt8:
-				newPixelData[i] = uint32(img.pixels.([]int8)[i])
-			case PixelTypeUInt16:
-				newPixelData[i] = uint32(img.pixels.([]uint16)[i])
-			case PixelTypeInt16:
-				newPixelData[i] = uint32(img.pixels.([]int16)[i])
-			case PixelTypeInt32:
-				newPixelData[i] = uint32(img.pixels.([]int32)[i])
-			case PixelTypeUInt64:
-				newPixelData[i] = uint32(img.pixels.([]uint64)[i])
-			case PixelTypeInt64:
-				newPixelData[i] = uint32(img.pixels.([]int64)[i])
-			case PixelTypeFloat32:
-				newPixelData[i] = uint32(img.pixels.([]float32)[i])
-			case PixelTypeFloat64:
-				newPixelData[i] = uint32(img.pixels.([]float64)[i])
+		for chunk := 0; chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > numPixels {
+				end = numPixels
 			}
+			wg.Add(1)
+			go func(start, end int) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					switch img.pixelType {
+					case PixelTypeUInt8:
+						newPixelData[i] = uint32(img.pixels.([]uint8)[i])
+					case PixelTypeInt8:
+						newPixelData[i] = uint32(img.pixels.([]int8)[i])
+					case PixelTypeUInt16:
+						newPixelData[i] = uint32(img.pixels.([]uint16)[i])
+					case PixelTypeInt16:
+						newPixelData[i] = uint32(img.pixels.([]int16)[i])
+					case PixelTypeInt32:
+						newPixelData[i] = uint32(img.pixels.([]int32)[i])
+					case PixelTypeUInt64:
+						newPixelData[i] = uint32(img.pixels.([]uint64)[i])
+					case PixelTypeInt64:
+						newPixelData[i] = uint32(img.pixels.([]int64)[i])
+					case PixelTypeFloat32:
+						newPixelData[i] = uint32(img.pixels.([]float32)[i])
+					case PixelTypeFloat64:
+						newPixelData[i] = uint32(img.pixels.([]float64)[i])
+					}
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		newImg.pixels = newPixelData
 	case PixelTypeInt32:
 		newPixelData := make([]int32, numPixels)
-		for i := 0; i < numPixels; i++ {
-			switch img.pixelType {
-			case PixelTypeUInt8:
-				newPixelData[i] = int32(img.pixels.([]uint8)[i])
-			case PixelTypeInt8:
-				newPixelData[i] = int32(img.pixels.([]int8)[i])
-			case PixelTypeUInt16:
-				newPixelData[i] = int32(img.pixels.([]uint16)[i])
-			case PixelTypeInt16:
-				newPixelData[i] = int32(img.pixels.([]int16)[i])
-			case PixelTypeUInt32:
-				newPixelData[i] = int32(img.pixels.([]uint32)[i])
-			case PixelTypeUInt64:
-				newPixelData[i] = int32(img.pixels.([]uint64)[i])
-			case PixelTypeInt64:
-				newPixelData[i] = int32(img.pixels.([]int64)[i])
-			case PixelTypeFloat32:
-				newPixelData[i] = int32(img.pixels.([]float32)[i])
-			case PixelTypeFloat64:
-				newPixelData[i] = int32(img.pixels.([]float64)[i])
+		for chunk := 0; chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > numPixels {
+				end = numPixels
 			}
+			wg.Add(1)
+			go func(start, end int) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					switch img.pixelType {
+					case PixelTypeUInt8:
+						newPixelData[i] = int32(img.pixels.([]uint8)[i])
+					case PixelTypeInt8:
+						newPixelData[i] = int32(img.pixels.([]int8)[i])
+					case PixelTypeUInt16:
+						newPixelData[i] = int32(img.pixels.([]uint16)[i])
+					case PixelTypeInt16:
+						newPixelData[i] = int32(img.pixels.([]int16)[i])
+					case PixelTypeUInt32:
+						newPixelData[i] = int32(img.pixels.([]uint32)[i])
+					case PixelTypeUInt64:
+						newPixelData[i] = int32(img.pixels.([]uint64)[i])
+					case PixelTypeInt64:
+						newPixelData[i] = int32(img.pixels.([]int64)[i])
+					case PixelTypeFloat32:
+						newPixelData[i] = int32(img.pixels.([]float32)[i])
+					case PixelTypeFloat64:
+						newPixelData[i] = int32(img.pixels.([]float64)[i])
+					}
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		newImg.pixels = newPixelData
 	case PixelTypeUInt64:
 		newPixelData := make([]uint64, numPixels)
-		for i := 0; i < numPixels; i++ {
-			switch img.pixelType {
-			case PixelTypeUInt8:
-				newPixelData[i] = uint64(img.pixels.([]uint8)[i])
-			case PixelTypeInt8:
-				newPixelData[i] = uint64(img.pixels.([]int8)[i])
-			case PixelTypeUInt16:
-				newPixelData[i] = uint64(img.pixels.([]uint16)[i])
-			case PixelTypeInt16:
-				newPixelData[i] = uint64(img.pixels.([]int16)[i])
-			case PixelTypeUInt32:
-				newPixelData[i] = uint64(img.pixels.([]uint32)[i])
-			case PixelTypeInt32:
-				newPixelData[i] = uint64(img.pixels.([]int32)[i])
-			case PixelTypeInt64:
-				newPixelData[i] = uint64(img.pixels.([]int64)[i])
-			case PixelTypeFloat32:
-				newPixelData[i] = uint64(img.pixels.([]float32)[i])
-			case PixelTypeFloat64:
-				newPixelData[i] = uint64(img.pixels.([]float64)[i])
+		for chunk := 0; chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > numPixels {
+				end = numPixels
 			}
+			wg.Add(1)
+			go func(start, end int) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					switch img.pixelType {
+					case PixelTypeUInt8:
+						newPixelData[i] = uint64(img.pixels.([]uint8)[i])
+					case PixelTypeInt8:
+						newPixelData[i] = uint64(img.pixels.([]int8)[i])
+					case PixelTypeUInt16:
+						newPixelData[i] = uint64(img.pixels.([]uint16)[i])
+					case PixelTypeInt16:
+						newPixelData[i] = uint64(img.pixels.([]int16)[i])
+					case PixelTypeUInt32:
+						newPixelData[i] = uint64(img.pixels.([]uint32)[i])
+					case PixelTypeInt32:
+						newPixelData[i] = uint64(img.pixels.([]int32)[i])
+					case PixelTypeInt64:
+						newPixelData[i] = uint64(img.pixels.([]int64)[i])
+					case PixelTypeFloat32:
+						newPixelData[i] = uint64(img.pixels.([]float32)[i])
+					case PixelTypeFloat64:
+						newPixelData[i] = uint64(img.pixels.([]float64)[i])
+					}
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		newImg.pixels = newPixelData
 	case PixelTypeInt64:
 		newPixelData := make([]int64, numPixels)
-		for i := 0; i < numPixels; i++ {
-			switch img.pixelType {
-			case PixelTypeUInt8:
-				newPixelData[i] = int64(img.pixels.([]uint8)[i])
-			case PixelTypeInt8:
-				newPixelData[i] = int64(img.pixels.([]int8)[i])
-			case PixelTypeUInt16:
-				newPixelData[i] = int64(img.pixels.([]uint16)[i])
-			case PixelTypeInt16:
-				newPixelData[i] = int64(img.pixels.([]int16)[i])
-			case PixelTypeUInt32:
-				newPixelData[i] = int64(img.pixels.([]uint32)[i])
-			case PixelTypeInt32:
-				newPixelData[i] = int64(img.pixels.([]int32)[i])
-			case PixelTypeUInt64:
-				newPixelData[i] = int64(img.pixels.([]uint64)[i])
-			case PixelTypeFloat32:
-				newPixelData[i] = int64(img.pixels.([]float32)[i])
-			case PixelTypeFloat64:
-				newPixelData[i] = int64(img.pixels.([]float64)[i])
+		for chunk := 0; chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > numPixels {
+				end = numPixels
 			}
+			wg.Add(1)
+			go func(start, end int) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					switch img.pixelType {
+					case PixelTypeUInt8:
+						newPixelData[i] = int64(img.pixels.([]uint8)[i])
+					case PixelTypeInt8:
+						newPixelData[i] = int64(img.pixels.([]int8)[i])
+					case PixelTypeUInt16:
+						newPixelData[i] = int64(img.pixels.([]uint16)[i])
+					case PixelTypeInt16:
+						newPixelData[i] = int64(img.pixels.([]int16)[i])
+					case PixelTypeUInt32:
+						newPixelData[i] = int64(img.pixels.([]uint32)[i])
+					case PixelTypeInt32:
+						newPixelData[i] = int64(img.pixels.([]int32)[i])
+					case PixelTypeUInt64:
+						newPixelData[i] = int64(img.pixels.([]uint64)[i])
+					case PixelTypeFloat32:
+						newPixelData[i] = int64(img.pixels.([]float32)[i])
+					case PixelTypeFloat64:
+						newPixelData[i] = int64(img.pixels.([]float64)[i])
+					}
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		newImg.pixels = newPixelData
 	case PixelTypeFloat32:
 		newPixelData := make([]float32, numPixels)
-		for i := 0; i < numPixels; i++ {
-			switch img.pixelType {
-			case PixelTypeUInt8:
-				newPixelData[i] = float32(img.pixels.([]uint8)[i])
-			case PixelTypeInt8:
-				newPixelData[i] = float32(img.pixels.([]int8)[i])
-			case PixelTypeUInt16:
-				newPixelData[i] = float32(img.pixels.([]uint16)[i])
-			case PixelTypeInt16:
-				newPixelData[i] = float32(img.pixels.([]int16)[i])
-			case PixelTypeUInt32:
-				newPixelData[i] = float32(img.pixels.([]uint32)[i])
-			case PixelTypeInt32:
-				newPixelData[i] = float32(img.pixels.([]int32)[i])
-			case PixelTypeUInt64:
-				newPixelData[i] = float32(img.pixels.([]uint64)[i])
-			case PixelTypeInt64:
-				newPixelData[i] = float32(img.pixels.([]int64)[i])
-			case PixelTypeFloat64:
-				newPixelData[i] = float32(img.pixels.([]float64)[i])
+		for chunk := 0; chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > numPixels {
+				end = numPixels
 			}
+			wg.Add(1)
+			go func(start, end int) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					switch img.pixelType {
+					case PixelTypeUInt8:
+						newPixelData[i] = float32(img.pixels.([]uint8)[i])
+					case PixelTypeInt8:
+						newPixelData[i] = float32(img.pixels.([]int8)[i])
+					case PixelTypeUInt16:
+						newPixelData[i] = float32(img.pixels.([]uint16)[i])
+					case PixelTypeInt16:
+						newPixelData[i] = float32(img.pixels.([]int16)[i])
+					case PixelTypeUInt32:
+						newPixelData[i] = float32(img.pixels.([]uint32)[i])
+					case PixelTypeInt32:
+						newPixelData[i] = float32(img.pixels.([]int32)[i])
+					case PixelTypeUInt64:
+						newPixelData[i] = float32(img.pixels.([]uint64)[i])
+					case PixelTypeInt64:
+						newPixelData[i] = float32(img.pixels.([]int64)[i])
+					case PixelTypeFloat64:
+						newPixelData[i] = float32(img.pixels.([]float64)[i])
+					}
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		newImg.pixels = newPixelData
 	case PixelTypeFloat64:
 		newPixelData := make([]float64, numPixels)
-		for i := 0; i < numPixels; i++ {
-			switch img.pixelType {
-			case PixelTypeUInt8:
-				newPixelData[i] = float64(img.pixels.([]uint8)[i])
-			case PixelTypeInt8:
-				newPixelData[i] = float64(img.pixels.([]int8)[i])
-			case PixelTypeUInt16:
-				newPixelData[i] = float64(img.pixels.([]uint16)[i])
-			case PixelTypeInt16:
-				newPixelData[i] = float64(img.pixels.([]int16)[i])
-			case PixelTypeUInt32:
-				newPixelData[i] = float64(img.pixels.([]uint32)[i])
-			case PixelTypeInt32:
-				newPixelData[i] = float64(img.pixels.([]int32)[i])
-			case PixelTypeUInt64:
-				newPixelData[i] = float64(img.pixels.([]uint64)[i])
-			case PixelTypeInt64:
-				newPixelData[i] = float64(img.pixels.([]int64)[i])
-			case PixelTypeFloat32:
-				newPixelData[i] = float64(img.pixels.([]float32)[i])
+		for chunk := 0; chunk < numGoroutines; chunk++ {
+			start := chunk * chunkSize
+			end := start + chunkSize
+			if end > numPixels {
+				end = numPixels
 			}
+			wg.Add(1)
+			go func(start, end int) {
+				defer wg.Done()
+				for i := start; i < end; i++ {
+					switch img.pixelType {
+					case PixelTypeUInt8:
+						newPixelData[i] = float64(img.pixels.([]uint8)[i])
+					case PixelTypeInt8:
+						newPixelData[i] = float64(img.pixels.([]int8)[i])
+					case PixelTypeUInt16:
+						newPixelData[i] = float64(img.pixels.([]uint16)[i])
+					case PixelTypeInt16:
+						newPixelData[i] = float64(img.pixels.([]int16)[i])
+					case PixelTypeUInt32:
+						newPixelData[i] = float64(img.pixels.([]uint32)[i])
+					case PixelTypeInt32:
+						newPixelData[i] = float64(img.pixels.([]int32)[i])
+					case PixelTypeUInt64:
+						newPixelData[i] = float64(img.pixels.([]uint64)[i])
+					case PixelTypeInt64:
+						newPixelData[i] = float64(img.pixels.([]int64)[i])
+					case PixelTypeFloat32:
+						newPixelData[i] = float64(img.pixels.([]float32)[i])
+					}
+				}
+			}(start, end)
 		}
+		wg.Wait()
 		newImg.pixels = newPixelData
 	default:
 		return nil, fmt.Errorf("unsupported pixel type: %d", pixelType)

--- a/image.go
+++ b/image.go
@@ -225,9 +225,6 @@ func GetArrayFromImage(img *Image) (any, error) {
 	chunkSize := uint64(img.NumPixels()) / numGoroutines
 	if chunkSize*numGoroutines < uint64(img.NumPixels()) {
 		chunkSize += 1
-		if numGoroutines > uint64(img.NumPixels()) {
-			numGoroutines = uint64(img.NumPixels())
-		}
 	}
 	wg := sync.WaitGroup{}
 	switch img.pixelType {
@@ -973,9 +970,6 @@ func (img *Image) AsType(pixelType int) (*Image, error) {
 	chunkSize := numPixels / numGoroutines
 	if chunkSize*numGoroutines < numPixels {
 		chunkSize += 1
-		if numGoroutines > numPixels {
-			numGoroutines = numPixels
-		}
 	}
 	wg := sync.WaitGroup{}
 	switch pixelType {

--- a/image_test.go
+++ b/image_test.go
@@ -354,15 +354,6 @@ func TestAsType(t *testing.T) {
 		t.Errorf("Expected pixel type to be PixelTypeUInt8, got %v", uin8Img.GetPixelType())
 	}
 
-	pixelValue, err := uin8Img.GetPixel([]uint32{0, 0})
-	if err != nil {
-		t.Errorf("Error getting pixel: %v", err)
-	}
-
-	if pixelValue.(uint8) != uint8(0) {
-		t.Errorf("Expected pixel value to be 0, got %v", pixelValue)
-	}
-
 	for i := 0; i < 10; i++ {
 		for j := 0; j < 10; j++ {
 			pixel, err := uin8Img.GetPixel([]uint32{uint32(i), uint32(j)})
@@ -370,12 +361,13 @@ func TestAsType(t *testing.T) {
 				t.Errorf("Error getting pixel: %v", err)
 			}
 
-			expected, err := img.GetPixel([]uint32{uint32(i), uint32(j)})
+			expected, err := img.GetPixelAsUInt8([]uint32{uint32(i), uint32(j)})
 			if err != nil {
 				t.Errorf("Error getting pixel as uint8: %v", err)
 			}
-			if pixel.(uint8) != uint8(expected.(float32)) {
-				t.Errorf("Expected pixel value %v to be %v, got %v", expected, uint8(expected.(float32)), pixel)
+
+			if pixel.(uint8) != expected {
+				t.Errorf("Expected pixel value %v to be %v, got %v", expected, pixel, expected)
 			}
 		}
 	}

--- a/interpolate.go
+++ b/interpolate.go
@@ -81,9 +81,6 @@ func linearResample(img *Image, interpolator LinearInterpolator) (*Image, error)
 	chunkSize := uint32(numPixels) / numGoroutines
 	if chunkSize*numGoroutines < uint32(numPixels) {
 		chunkSize += 1
-		if numGoroutines > uint32(numPixels) {
-			numGoroutines = uint32(numPixels)
-		}
 	}
 	wg := sync.WaitGroup{}
 	for chunk := uint32(0); chunk < numGoroutines; chunk++ {

--- a/morph.go
+++ b/morph.go
@@ -1,6 +1,9 @@
 package imagetk
 
-import "sync"
+import (
+	"runtime"
+	"sync"
+)
 
 const (
 	MORPH_OPEN = iota
@@ -87,26 +90,41 @@ func binaryDilate3D(image *Image, kernelSize int) (*Image, error) {
 		}
 	}
 
+	numGoroutines := uint32(runtime.NumCPU())
+	chunkSize := size[2] / numGoroutines
+	if chunkSize*numGoroutines < size[2] {
+		chunkSize += 1
+		if numGoroutines > size[2] {
+			numGoroutines = size[2]
+		}
+	}
 	wg := sync.WaitGroup{}
-	for z := uint32(0); z < size[2]; z++ {
+	for chunk := uint32(0); chunk < numGoroutines; chunk++ {
+		start := chunk * chunkSize
+		end := start + chunkSize
+		if end > size[2] {
+			end = size[2]
+		}
 		wg.Add(1)
-		go func(z uint32) {
+		go func(start, end uint32) {
 			defer wg.Done()
-			for y := uint32(0); y < size[1]; y++ {
-				for x := uint32(0); x < size[0]; x++ {
-					// Check if the current pixel is set to 1
-					if int8Array[z][y][x] == 1 {
-						// Expand around the pixel, respecting boundaries
-						for i := -kernelSize / 2; i <= kernelSize/2; i++ {
-							for j := -kernelSize / 2; j <= kernelSize/2; j++ {
-								for k := -kernelSize / 2; k <= kernelSize/2; k++ {
-									newZ := int(z) + i
-									newY := int(y) + j
-									newX := int(x) + k
+			for z := start; z < end; z++ {
+				for y := uint32(0); y < size[1]; y++ {
+					for x := uint32(0); x < size[0]; x++ {
+						// Check if the current pixel is set to 1
+						if int8Array[z][y][x] == 1 {
+							// Expand around the pixel, respecting boundaries
+							for i := -kernelSize / 2; i <= kernelSize/2; i++ {
+								for j := -kernelSize / 2; j <= kernelSize/2; j++ {
+									for k := -kernelSize / 2; k <= kernelSize/2; k++ {
+										newZ := int(z) + i
+										newY := int(y) + j
+										newX := int(x) + k
 
-									// Ensure the new coordinates are within bounds
-									if newZ >= 0 && newZ < int(size[2]) && newY >= 0 && newY < int(size[1]) && newX >= 0 && newX < int(size[0]) {
-										expandedArray[newZ][newY][newX] = 1
+										// Ensure the new coordinates are within bounds
+										if newZ >= 0 && newZ < int(size[2]) && newY >= 0 && newY < int(size[1]) && newX >= 0 && newX < int(size[0]) {
+											expandedArray[newZ][newY][newX] = 1
+										}
 									}
 								}
 							}
@@ -114,7 +132,7 @@ func binaryDilate3D(image *Image, kernelSize int) (*Image, error) {
 					}
 				}
 			}
-		}(z)
+		}(start, end)
 	}
 	wg.Wait()
 
@@ -206,39 +224,54 @@ func binaryErode3D(image *Image, kernelSize int) (*Image, error) {
 
 	halfKernel := kernelSize / 2
 
+	numGoroutines := uint32(runtime.NumCPU())
+	chunkSize := size[2] / numGoroutines
+	if chunkSize*numGoroutines < size[2] {
+		chunkSize += 1
+		if numGoroutines > size[2] {
+			numGoroutines = size[2]
+		}
+	}
 	wg := sync.WaitGroup{}
-	for z := uint32(0); z < size[2]; z++ {
+	for chunk := uint32(0); chunk < numGoroutines; chunk++ {
+		start := chunk * chunkSize
+		end := start + chunkSize
+		if end > size[2] {
+			end = size[2]
+		}
 		wg.Add(1)
-		go func(z uint32) {
+		go func(start, end uint32) {
 			defer wg.Done()
-			for y := uint32(0); y < size[1]; y++ {
-				for x := uint32(0); x < size[0]; x++ {
-					// Only process pixels that are 1 in the input
-					if int8Array[z][y][x] == 1 {
-						// Check all pixels in the kernel neighborhood
-						for dz := -halfKernel; dz <= halfKernel; dz++ {
-							for dy := -halfKernel; dy <= halfKernel; dy++ {
-								for dx := -halfKernel; dx <= halfKernel; dx++ {
-									newZ := int(z) + dz
-									newY := int(y) + dy
-									newX := int(x) + dx
+			for z := start; z < end; z++ {
+				for y := uint32(0); y < size[1]; y++ {
+					for x := uint32(0); x < size[0]; x++ {
+						// Only process pixels that are 1 in the input
+						if int8Array[z][y][x] == 1 {
+							// Check all pixels in the kernel neighborhood
+							for dz := -halfKernel; dz <= halfKernel; dz++ {
+								for dy := -halfKernel; dy <= halfKernel; dy++ {
+									for dx := -halfKernel; dx <= halfKernel; dx++ {
+										newZ := int(z) + dz
+										newY := int(y) + dy
+										newX := int(x) + dx
 
-									// If any neighbor is outside bounds or 0, erode the current pixel
-									if newZ < 0 || newZ >= int(size[2]) ||
-										newY < 0 || newY >= int(size[1]) ||
-										newX < 0 || newX >= int(size[0]) ||
-										int8Array[newZ][newY][newX] == 0 {
-										erodedArray[z][y][x] = 0
-										goto nextPixel // Break out of all loops
+										// If any neighbor is outside bounds or 0, erode the current pixel
+										if newZ < 0 || newZ >= int(size[2]) ||
+											newY < 0 || newY >= int(size[1]) ||
+											newX < 0 || newX >= int(size[0]) ||
+											int8Array[newZ][newY][newX] == 0 {
+											erodedArray[z][y][x] = 0
+											goto nextPixel // Break out of all loops
+										}
 									}
 								}
 							}
 						}
+					nextPixel:
 					}
-				nextPixel:
 				}
 			}
-		}(z)
+		}(start, end)
 	}
 	wg.Wait()
 

--- a/morph.go
+++ b/morph.go
@@ -94,9 +94,6 @@ func binaryDilate3D(image *Image, kernelSize int) (*Image, error) {
 	chunkSize := size[2] / numGoroutines
 	if chunkSize*numGoroutines < size[2] {
 		chunkSize += 1
-		if numGoroutines > size[2] {
-			numGoroutines = size[2]
-		}
 	}
 	wg := sync.WaitGroup{}
 	for chunk := uint32(0); chunk < numGoroutines; chunk++ {
@@ -228,9 +225,6 @@ func binaryErode3D(image *Image, kernelSize int) (*Image, error) {
 	chunkSize := size[2] / numGoroutines
 	if chunkSize*numGoroutines < size[2] {
 		chunkSize += 1
-		if numGoroutines > size[2] {
-			numGoroutines = size[2]
-		}
 	}
 	wg := sync.WaitGroup{}
 	for chunk := uint32(0); chunk < numGoroutines; chunk++ {


### PR DESCRIPTION
This pull request introduces parallel processing to several functions in the `imagetk` package to improve performance by utilizing multiple CPU cores. The changes include the addition of goroutines and synchronization mechanisms to handle concurrent execution.

Parallel Processing Enhancements:

* [`image.go`](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R6-R7): Modified `GetArrayFromImage` and `AsType` functions to use goroutines and `sync.WaitGroup` for parallel processing of image pixels. This change splits the work into chunks based on the number of CPU cores available. [[1]](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R6-R7) [[2]](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1L222-R498) [[3]](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R969-R987) [[4]](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R1009-R1024) [[5]](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R1046-R1061) [[6]](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R1083-R1098) [[7]](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R1120-R1135) [[8]](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R1157-R1172) [[9]](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R1194-R1209) [[10]](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R1231-R1246) [[11]](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R1268-R1283) [[12]](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R1305-R1320) [[13]](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R1342-R1344)

* [`interpolate.go`](diffhunk://#diff-06a81cf280e7e45c951e1d5b98a5473d88b79230e7d8bd50a679d536485cd572L3-R7): Updated `linearResample` function to utilize goroutines for parallel resampling of image data, improving performance by processing chunks concurrently. [[1]](diffhunk://#diff-06a81cf280e7e45c951e1d5b98a5473d88b79230e7d8bd50a679d536485cd572L3-R7) [[2]](diffhunk://#diff-06a81cf280e7e45c951e1d5b98a5473d88b79230e7d8bd50a679d536485cd572L76-R124)

* [`morph.go`](diffhunk://#diff-d155ad793bd62e6ea4c44ba985049ecb13a4f4f32f799791b2bce695a16c0101L3-R6): Enhanced `binaryDilate3D` function to perform morphological operations in parallel using multiple goroutines, which speeds up the dilation process. [[1]](diffhunk://#diff-d155ad793bd62e6ea4c44ba985049ecb13a4f4f32f799791b2bce695a16c0101L3-R6) [[2]](diffhunk://#diff-d155ad793bd62e6ea4c44ba985049ecb13a4f4f32f799791b2bce695a16c0101R93-R108) [[3]](diffhunk://#diff-d155ad793bd62e6ea4c44ba985049ecb13a4f4f32f799791b2bce695a16c0101L117-R132)

Test Adjustments:

* [`image_test.go`](diffhunk://#diff-8800f431c68bc7b72919839bf923ca360c922aa558ad72c8f23919a81a663531L357-R370): Modified the `TestAsType` function to ensure compatibility with the new parallel processing changes, including removing redundant pixel value checks and updating pixel retrieval methods.