### PR TITLE
Add Nearest Interpolation

### DIFF
--- a/image.go
+++ b/image.go
@@ -522,30 +522,43 @@ func (img *Image) GetPixelType() int {
 	return img.pixelType
 }
 
+// IsPixelType checks if the pixel type of the image matches the given pixel type.
 func (img *Image) IsPixelType(pixelType int) bool {
 	return img.pixelType == pixelType
 }
 
+// GetDimension returns the number of dimensions of the image.
 func (img *Image) GetDimension() uint32 {
 	return img.dimension
 }
 
+// GetSize returns the size of the image.
 func (img *Image) GetSize() []uint32 {
 	return img.size
 }
 
+// GetSpacing returns the spacing of the image.
 func (img *Image) GetSpacing() []float64 {
 	return img.spacing
 }
 
+// GetOrigin returns the origin of the image.
 func (img *Image) GetOrigin() []float64 {
 	return img.origin
 }
 
+// GetDirection returns the direction matrix of the image.
 func (img *Image) GetDirection() [9]float64 {
 	return img.direction
 }
 
+// GetPixel returns the pixel value at the given index.
+// Parameters:
+//   - index: A slice of uint32 representing the index of the pixel.
+//
+// Returns:
+//   - any: The pixel value as the type of the image.
+//   - error: An error if the index is out of range.
 func (img *Image) GetPixel(index []uint32) (any, error) {
 	if len(index) != int(img.dimension) {
 		return nil, fmt.Errorf("invalid index length: %d", len(index))
@@ -583,6 +596,13 @@ func (img *Image) GetPixel(index []uint32) (any, error) {
 	}
 }
 
+// GetPixelAsUInt8 returns the pixel value at the given index as a uint8.
+// Parameters:
+//   - index: A slice of uint32 representing the index of the pixel.
+//
+// Returns:
+//   - uint8: The pixel value as a uint8.
+//   - error: An error if the index is out of range.
 func (img *Image) GetPixelAsUInt8(index []uint32) (uint8, error) {
 	idx := uint32(0)
 	for i := len(index) - 1; i >= 0; i-- {
@@ -617,6 +637,13 @@ func (img *Image) GetPixelAsUInt8(index []uint32) (uint8, error) {
 	}
 }
 
+// GetPixelAsInt8 returns the pixel value at the given index as a int8.
+// Parameters:
+//   - index: A slice of uint32 representing the index of the pixel.
+//
+// Returns:
+//   - int8: The pixel value as a int8.
+//   - error: An error if the index is out of range.
 func (img *Image) GetPixelAsInt8(index []uint32) (int8, error) {
 	idx := uint32(0)
 	for i := len(index) - 1; i >= 0; i-- {
@@ -651,6 +678,13 @@ func (img *Image) GetPixelAsInt8(index []uint32) (int8, error) {
 	}
 }
 
+// GetPixelAsUInt16 returns the pixel value at the given index as a uint16.
+// Parameters:
+//   - index: A slice of uint32 representing the index of the pixel.
+//
+// Returns:
+//   - uint16: The pixel value as a uint16.
+//   - error: An error if the index is out of range.
 func (img *Image) GetPixelAsUInt16(index []uint32) (uint16, error) {
 	idx := uint32(0)
 	for i := len(index) - 1; i >= 0; i-- {
@@ -685,6 +719,13 @@ func (img *Image) GetPixelAsUInt16(index []uint32) (uint16, error) {
 	}
 }
 
+// GetPixelAsInt16 returns the pixel value at the given index as a int16.
+// Parameters:
+//   - index: A slice of uint32 representing the index of the pixel.
+//
+// Returns:
+//   - int16: The pixel value as a int16.
+//   - error: An error if the index is out of range.
 func (img *Image) GetPixelAsInt16(index []uint32) (int16, error) {
 	idx := uint32(0)
 	for i := len(index) - 1; i >= 0; i-- {
@@ -719,6 +760,13 @@ func (img *Image) GetPixelAsInt16(index []uint32) (int16, error) {
 	}
 }
 
+// GetPixelAsUInt32 returns the pixel value at the given index as a uint32.
+// Parameters:
+//   - index: A slice of uint32 representing the index of the pixel.
+//
+// Returns:
+//   - uint32: The pixel value as a uint32.
+//   - error: An error if the index is out of range.
 func (img *Image) GetPixelAsUInt32(index []uint32) (uint32, error) {
 	idx := uint32(0)
 	for i := len(index) - 1; i >= 0; i-- {
@@ -753,6 +801,13 @@ func (img *Image) GetPixelAsUInt32(index []uint32) (uint32, error) {
 	}
 }
 
+// GetPixelAsInt32 returns the pixel value at the given index as a int32.
+// Parameters:
+//   - index: A slice of uint32 representing the index of the pixel.
+//
+// Returns:
+//   - int32: The pixel value as a int32.
+//   - error: An error if the index is out of range.
 func (img *Image) GetPixelAsInt32(index []uint32) (int32, error) {
 	idx := uint32(0)
 	for i := len(index) - 1; i >= 0; i-- {
@@ -787,6 +842,13 @@ func (img *Image) GetPixelAsInt32(index []uint32) (int32, error) {
 	}
 }
 
+// GetPixelAsUInt64 returns the pixel value at the given index as a uint64.
+// Parameters:
+//   - index: A slice of uint32 representing the index of the pixel.
+//
+// Returns:
+//   - uint64: The pixel value as a uint64.
+//   - error: An error if the index is out of range.
 func (img *Image) GetPixelAsUInt64(index []uint32) (uint64, error) {
 	idx := uint32(0)
 	for i := len(index) - 1; i >= 0; i-- {
@@ -821,6 +883,13 @@ func (img *Image) GetPixelAsUInt64(index []uint32) (uint64, error) {
 	}
 }
 
+// GetPixelAsInt64 returns the pixel value at the given index as a int64.
+// Parameters:
+//   - index: A slice of uint32 representing the index of the pixel.
+//
+// Returns:
+//   - int64: The pixel value as a int64.
+//   - error: An error if the index is out of range.
 func (img *Image) GetPixelAsInt64(index []uint32) (int64, error) {
 	idx := uint32(0)
 	for i := len(index) - 1; i >= 0; i-- {
@@ -855,6 +924,13 @@ func (img *Image) GetPixelAsInt64(index []uint32) (int64, error) {
 	}
 }
 
+// GetPixelAsFloat32 returns the pixel value at the given index as a float32.
+// Parameters:
+//   - index: A slice of uint32 representing the index of the pixel.
+//
+// Returns:
+//   - float32: The pixel value as a float32.
+//   - error: An error if the index is out of range.
 func (img *Image) GetPixelAsFloat32(index []uint32) (float32, error) {
 	idx := uint32(0)
 	for i := len(index) - 1; i >= 0; i-- {
@@ -889,6 +965,13 @@ func (img *Image) GetPixelAsFloat32(index []uint32) (float32, error) {
 	}
 }
 
+// GetPixelAsFloat64 returns the pixel value at the given index as a float64.
+// Parameters:
+//   - index: A slice of uint32 representing the index of the pixel.
+//
+// Returns:
+//   - float64: The pixel value as a float64.
+//   - error: An error if the index is out of range.
 func (img *Image) GetPixelAsFloat64(index []uint32) (float64, error) {
 	idx := uint32(0)
 	for i := len(index) - 1; i >= 0; i-- {

--- a/interpolate.go
+++ b/interpolate.go
@@ -14,6 +14,14 @@ type LinearInterpolator struct {
 	FillType  int
 }
 
+type NearestInterpolator struct {
+	Size      []uint32
+	Spacing   []float64
+	Origin    []float64
+	Direction [9]float64
+	FillType  int
+}
+
 const (
 	FillTypeZero = iota
 	FillTypeNearest
@@ -31,6 +39,8 @@ func (img *Image) Resample(interpolator any) (*Image, error) {
 	switch interpolator := interpolator.(type) {
 	case LinearInterpolator:
 		return linearResample(img, interpolator)
+	case NearestInterpolator:
+		return nearestResample(img, interpolator)
 	default:
 		return nil, fmt.Errorf("unknown interpolation type")
 	}
@@ -114,6 +124,109 @@ func linearResample(img *Image, interpolator LinearInterpolator) (*Image, error)
 					index[j] = uint32(idx / uint32(strides[j]))
 					idx %= uint32(strides[j])
 				}
+				err = newImg.SetPixel(index, pixelValue)
+				if err != nil {
+					return
+				}
+			}
+		}(start, end)
+	}
+	wg.Wait()
+
+	return newImg, nil
+}
+
+func nearestResample(img *Image, interpolator NearestInterpolator) (*Image, error) {
+	// Create a new image
+	newImg, err := NewImage(interpolator.Size, img.GetPixelType())
+	if err != nil {
+		return nil, err
+	}
+
+	// Copy the origin, spacing and direction with default values if not specified
+	if interpolator.Origin != nil {
+		newImg.SetOrigin(interpolator.Origin)
+	} else {
+		return nil, fmt.Errorf("origin is not specified")
+	}
+
+	if interpolator.Spacing != nil {
+		newImg.SetSpacing(interpolator.Spacing)
+	} else {
+		return nil, fmt.Errorf("spacing is not specified")
+	}
+
+	if interpolator.Direction != [9]float64{} {
+		newImg.SetDirection(interpolator.Direction)
+	} else {
+		return nil, fmt.Errorf("direction is not specified")
+	}
+
+	if interpolator.Size == nil {
+		return nil, fmt.Errorf("size is not specified")
+	}
+
+	numPixels := 1
+	for i := 0; i < len(interpolator.Size); i++ {
+		numPixels *= int(interpolator.Size[i])
+	}
+
+	strides := make([]int, len(interpolator.Size))
+	strides[len(interpolator.Size)-1] = 1
+	for i := len(interpolator.Size) - 2; i >= 0; i-- {
+		strides[i] = strides[i+1] * int(interpolator.Size[i+1])
+	}
+
+	numGoroutines := uint32(runtime.NumCPU())
+	chunkSize := uint32(numPixels) / numGoroutines
+	if chunkSize*numGoroutines < uint32(numPixels) {
+		chunkSize += 1
+	}
+	wg := sync.WaitGroup{}
+	for chunk := uint32(0); chunk < numGoroutines; chunk++ {
+		start := chunk * chunkSize
+		end := start + chunkSize
+		if end > uint32(numPixels) {
+			end = uint32(numPixels)
+		}
+		wg.Add(1)
+		go func(start, end uint32) {
+			defer wg.Done()
+			for i := start; i < end; i++ {
+				point := make([]float64, len(interpolator.Size))
+				idx := i
+				for j := 0; j < len(interpolator.Size); j++ {
+					point[j] = float64(idx/uint32(strides[j]))*interpolator.Spacing[j] + interpolator.Origin[j]
+					idx %= uint32(strides[j])
+				}
+
+				// Transform the physical point back to input image space
+				inputPoint := make([]float64, len(interpolator.Size))
+				for j := range point {
+					// Convert physical point to input image space using correct transformation
+					// Subtract 0.5 because pixel coordinates are at center of pixel
+					inputPoint[j] = ((point[j] - img.origin[j]) / img.spacing[j]) - 0.5
+					// Round to nearest integer for nearest neighbor
+					inputPoint[j] = float64(int(inputPoint[j]+0.5)) + 0.5
+				}
+
+				value, err := img.GetPixelFromPoint(inputPoint, FillTypeNearest)
+				if err != nil {
+					return
+				}
+
+				pixelValue, err := getValueAsPixelType(value, newImg.pixelType)
+				if err != nil {
+					return
+				}
+
+				index := make([]uint32, len(interpolator.Size))
+				idx = i
+				for j := 0; j < len(interpolator.Size); j++ {
+					index[j] = uint32(idx / uint32(strides[j]))
+					idx %= uint32(strides[j])
+				}
+
 				err = newImg.SetPixel(index, pixelValue)
 				if err != nil {
 					return

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -83,3 +83,55 @@ func TestLinearInterpolator2(t *testing.T) {
 	}
 
 }
+
+func TestNearestInterpolator(t *testing.T) {
+	pixelData := [][]float32{
+		{0, 0, 0, 0},
+		{0, 1, 1, 0},
+		{0, 1, 1, 0},
+		{0, 0, 0, 0},
+	}
+	img, err := GetImageFromArray(pixelData)
+	if err != nil {
+		t.Errorf("Error creating image from array: %v", err)
+	}
+	img.SetOrigin([]float64{0.5, 0.5})
+
+	interpolator := NearestInterpolator{
+		Size:      []uint32{8, 8},
+		Spacing:   []float64{0.5, 0.5},
+		Origin:    []float64{0.25, 0.25},
+		Direction: [9]float64{1, 0, 0, 0, 1, 0, 0, 0, 1},
+	}
+	newImg, err := img.Resample(interpolator)
+	if err != nil {
+		t.Errorf("Error resampling image: %v", err)
+	}
+
+	size := newImg.GetSize()
+	if size[0] != 8 || size[1] != 8 {
+		t.Errorf("Expected size to be [8, 8], got %v", size)
+	}
+
+	// Test center pixel value
+	pixelValue, err := newImg.GetPixelAsFloat32([]uint32{3, 3})
+	if err != nil {
+		t.Errorf("Error getting pixel value: %v", err)
+	}
+
+	expected := float32(1)
+	if pixelValue != expected {
+		t.Errorf("Expected pixel value to be %v, got %v", expected, pixelValue)
+	}
+
+	// Test corner pixel value (should be 0)
+	cornerValue, err := newImg.GetPixelAsFloat32([]uint32{0, 0})
+	if err != nil {
+		t.Errorf("Error getting corner pixel value: %v", err)
+	}
+
+	expectedCorner := float32(0)
+	if cornerValue != expectedCorner {
+		t.Errorf("Expected corner pixel value to be %v, got %v", expectedCorner, cornerValue)
+	}
+}

--- a/morph.go
+++ b/morph.go
@@ -10,6 +10,14 @@ const (
 	MORPH_CLOSE
 )
 
+// BinaryDilate dilates the binary image.
+// Parameters:
+//   - image: The image to dilate.
+//   - kernelSize: The size of the kernel to use for the dilation.
+//
+// Returns:
+//   - *Image: The resulting image after dilation.
+//   - error: An error if the operation fails.
 func BinaryDilate(image *Image, kernelSize int) (*Image, error) {
 	switch image.GetDimension() {
 	case 2:
@@ -21,6 +29,14 @@ func BinaryDilate(image *Image, kernelSize int) (*Image, error) {
 	}
 }
 
+// BinaryErode erodes the binary image.
+// Parameters:
+//   - image: The image to erode.
+//   - kernelSize: The size of the kernel to use for the erosion.
+//
+// Returns:
+//   - *Image: The resulting image after erosion.
+//   - error: An error if the operation fails.
 func BinaryErode(image *Image, kernelSize int) (*Image, error) {
 	switch image.GetDimension() {
 	case 2:
@@ -32,6 +48,16 @@ func BinaryErode(image *Image, kernelSize int) (*Image, error) {
 	}
 }
 
+// Morphology performs morphological operations on the image.
+// Parameters:
+//   - image: The image to perform the morphological operation on.
+//   - operation: The morphological operation to perform.
+//   - kernelSize: The size of the kernel to use for the morphological operation.
+//   - iterations: The number of iterations to perform.
+//
+// Returns:
+//   - *Image: The resulting image after the morphological operation.
+//   - error: An error if the operation fails.
 func Morphology(image *Image, operation, kernelSize, iterations int) (*Image, error) {
 	var output *Image
 	var err error

--- a/point.go
+++ b/point.go
@@ -48,7 +48,13 @@ func invert3x3(m [9]float64) ([9]float64, error) {
 }
 
 // GetPixelFromPoint returns the interpolated pixel value at a given physical point in the image.
-// If the point is outside the image bounds, it handles it according to fillType.
+// Parameters:
+//   - point: A slice of float64 representing the physical point.
+//   - fillType: The type of fill to use if the point is outside the image bounds.
+//
+// Returns:
+//   - float64: The interpolated pixel value.
+//   - error: An error if the operation fails.
 func (img *Image) GetPixelFromPoint(point []float64, fillType int) (float64, error) {
 	if len(point) != int(img.dimension) {
 		return 0.0, fmt.Errorf("point dimension does not match image dimension")

--- a/stats.go
+++ b/stats.go
@@ -5,6 +5,10 @@ import (
 	"sort"
 )
 
+// Min returns the minimum pixel value in the image.
+//
+// Returns:
+//   - any: The minimum pixel value in the image as the type of the image.
 func (img *Image) Min() any {
 	switch img.pixelType {
 	case PixelTypeUInt8:
@@ -92,6 +96,10 @@ func (img *Image) Min() any {
 	}
 }
 
+// Max returns the maximum pixel value in the image.
+//
+// Returns:
+//   - any: The maximum pixel value in the image as the type of the image.
 func (img *Image) Max() any {
 	switch img.pixelType {
 	case PixelTypeUInt8:
@@ -180,7 +188,9 @@ func (img *Image) Max() any {
 }
 
 // Sum returns the sum of all pixel values in the image.
-// Unsigned pixel types are summed as uint64, signed pixel types are summed as int64, and floating-point pixel types are summed as float64.
+//
+// Returns:
+//   - any: The sum of all pixel values in the image. Unsigned pixel types are summed as uint64, signed pixel types are summed as int64, and floating-point pixel types are summed as float64.
 func (img *Image) Sum() any {
 	switch img.pixelType {
 	case PixelTypeUInt8:
@@ -249,7 +259,9 @@ func (img *Image) Sum() any {
 }
 
 // Product returns the product of all pixel values in the image.
-// Unsigned pixel types are multiplied as uint64, signed pixel types are multiplied as int64, and floating-point pixel types are multiplied as float64.
+//
+// Returns:
+//   - any: The product of all pixel values in the image. Unsigned pixel types are multiplied as uint64, signed pixel types are multiplied as int64, and floating-point pixel types are multiplied as float64.
 func (img *Image) Product() any {
 	switch img.pixelType {
 	case PixelTypeUInt8:
@@ -318,6 +330,9 @@ func (img *Image) Product() any {
 }
 
 // ExactMean returns the exact mean of all pixel values in the image.
+//
+// Returns:
+//   - float64: The exact mean of the image.
 func (img *Image) ExactMean() float64 {
 	switch img.pixelType {
 	case PixelTypeUInt8:
@@ -385,6 +400,10 @@ func (img *Image) ExactMean() float64 {
 	}
 }
 
+// Mean returns the mean of the image.
+//
+// Returns:
+//   - any: The mean of the image as the type of the image.
 func (img *Image) Mean() any {
 	switch img.pixelType {
 	case PixelTypeUInt8:
@@ -452,6 +471,10 @@ func (img *Image) Mean() any {
 	}
 }
 
+// Median returns the median of the image.
+//
+// Returns:
+//   - float64: The median of the image.
 func (img *Image) Median() float64 {
 	switch img.pixelType {
 	case PixelTypeUInt8:
@@ -519,6 +542,10 @@ func (img *Image) Median() float64 {
 	}
 }
 
+// Std returns the standard deviation of the image.
+//
+// Returns:
+//   - any: The standard deviation of the image.
 func (img *Image) Std() any {
 	switch img.pixelType {
 	case PixelTypeUInt8:
@@ -606,6 +633,12 @@ func (img *Image) Std() any {
 	}
 }
 
+// Percentile returns the percentile value of the image.
+// Parameters:
+//   - p: The percentile to compute (between 0 and 1).
+//
+// Returns:
+//   - float64: The percentile value.
 func (img *Image) Percentile(p float64) float64 {
 	switch img.pixelType {
 	case PixelTypeUInt8:


### PR DESCRIPTION
This pull request includes several additions to the `image.go`, `interpolate.go`, `morph.go`, `point.go`, and `stats.go` files, primarily focusing on adding new methods and improving documentation for existing methods. The most important change is implementing a new interpolation type.

### New Interpolation Type:
* [`interpolate.go`](diffhunk://#diff-06a81cf280e7e45c951e1d5b98a5473d88b79230e7d8bd50a679d536485cd572R17-R24): Introduced `NearestInterpolator` and implemented the `nearestResample` function to support nearest neighbor interpolation. [[1]](diffhunk://#diff-06a81cf280e7e45c951e1d5b98a5473d88b79230e7d8bd50a679d536485cd572R17-R24) [[2]](diffhunk://#diff-06a81cf280e7e45c951e1d5b98a5473d88b79230e7d8bd50a679d536485cd572R42-R43) [[3]](diffhunk://#diff-06a81cf280e7e45c951e1d5b98a5473d88b79230e7d8bd50a679d536485cd572R138-R240)
* [`interpolate_test.go`](diffhunk://#diff-d8e59ad4e52a3e9a051982da2b17189cf0a8e99ce6fcab2518dcaa19f8cfce5aR86-R137): Added test `TestNearestInterpolator` to verify the functionality of the new nearest neighbor interpolation.

### Improved Documentation:
* [`point.go`](diffhunk://#diff-b3419f941efd96f6d5f11d261d273cc4f0afa8560ed79b9885ae40dd18379e80L51-R57): Enhanced documentation for the `GetPixelFromPoint` method to include parameter descriptions and return values.
* [`stats.go`](diffhunk://#diff-9f6cddeabc26d57e3837fe66df90a6288f56e8a0e898cb6004d098da521583aeR8-R11): Added return value descriptions for statistical methods such as `Min`, `Max`, `Sum`, `Product`, `ExactMean`, `Mean`, `Median`, and `Std`. [[1]](diffhunk://#diff-9f6cddeabc26d57e3837fe66df90a6288f56e8a0e898cb6004d098da521583aeR8-R11) [[2]](diffhunk://#diff-9f6cddeabc26d57e3837fe66df90a6288f56e8a0e898cb6004d098da521583aeR99-R102) [[3]](diffhunk://#diff-9f6cddeabc26d57e3837fe66df90a6288f56e8a0e898cb6004d098da521583aeL183-R193) [[4]](diffhunk://#diff-9f6cddeabc26d57e3837fe66df90a6288f56e8a0e898cb6004d098da521583aeL252-R264) [[5]](diffhunk://#diff-9f6cddeabc26d57e3837fe66df90a6288f56e8a0e898cb6004d098da521583aeR333-R335) [[6]](diffhunk://#diff-9f6cddeabc26d57e3837fe66df90a6288f56e8a0e898cb6004d098da521583aeR403-R406) [[7]](diffhunk://#diff-9f6cddeabc26d57e3837fe66df90a6288f56e8a0e898cb6004d098da521583aeR474-R477) [[8]](diffhunk://#diff-9f6cddeabc26d57e3837fe66df90a6288f56e8a0e898cb6004d098da521583aeR545-R548)