### PR TITLE
Add documentation and modified resampling to handle direction correctly

### DIFF
--- a/image.go
+++ b/image.go
@@ -1,3 +1,4 @@
+// Package image provides functions for creating, manipulating, and analyzing images.
 package imagetk
 
 import (

--- a/image.go
+++ b/image.go
@@ -36,13 +36,13 @@ const (
 // dimensions, size, spacing, origin, and direction.
 //
 // Fields:
-// - pixels: The pixel data of the image, type can vary.
-// - pixelType: An integer representing the type of pixels.
-// - dimension: The number of dimensions of the image (2<=N<=3).
-// - size: A slice of uint32 representing the size of the image in each dimension (2<=N<=3).
-// - spacing: A slice of float64 representing the spacing between pixels in each dimension.
-// - origin: A slice of float64 representing the origin of the image.
-// - direction: An array of 9 float64 values representing the direction cosines of the image.
+//   - pixels: The pixel data of the image, type can vary.
+//   - pixelType: An integer representing the type of pixels.
+//   - dimension: The number of dimensions of the image (2<=N<=3).
+//   - size: A slice of uint32 representing the size of the image in each dimension (2<=N<=3).
+//   - spacing: A slice of float64 representing the spacing between pixels in each dimension.
+//   - origin: A slice of float64 representing the origin of the image.
+//   - direction: An array of 9 float64 values representing the direction cosines of the image.
 type Image struct {
 	pixels    any
 	pixelType int

--- a/interpolate.go
+++ b/interpolate.go
@@ -105,10 +105,19 @@ func linearResample(img *Image, interpolator LinearInterpolator) (*Image, error)
 			for i := start; i < end; i++ {
 				point := make([]float64, len(interpolator.Size))
 				idx := i
+				indices := make([]float64, len(interpolator.Size))
 				for j := 0; j < len(interpolator.Size); j++ {
-					point[j] = float64(idx/uint32(strides[j]))*interpolator.Spacing[j] + interpolator.Origin[j]
+					indices[j] = float64(idx / uint32(strides[j]))
 					idx %= uint32(strides[j])
 				}
+
+				for j := 0; j < len(interpolator.Size); j++ {
+					for k := 0; k < len(interpolator.Size); k++ {
+						point[j] += interpolator.Direction[j*3+k] * indices[k] * interpolator.Spacing[k]
+					}
+					point[j] += interpolator.Origin[j]
+				}
+
 				value, err := img.GetPixelFromPoint(point, interpolator.FillType)
 				if err != nil {
 					return
@@ -195,9 +204,17 @@ func nearestResample(img *Image, interpolator NearestInterpolator) (*Image, erro
 			for i := start; i < end; i++ {
 				point := make([]float64, len(interpolator.Size))
 				idx := i
+				indices := make([]float64, len(interpolator.Size))
 				for j := 0; j < len(interpolator.Size); j++ {
-					point[j] = float64(idx/uint32(strides[j]))*interpolator.Spacing[j] + interpolator.Origin[j]
+					indices[j] = float64(idx / uint32(strides[j]))
 					idx %= uint32(strides[j])
+				}
+
+				for j := 0; j < len(interpolator.Size); j++ {
+					for k := 0; k < len(interpolator.Size); k++ {
+						point[j] += interpolator.Direction[j*3+k] * indices[k] * interpolator.Spacing[k]
+					}
+					point[j] += interpolator.Origin[j]
 				}
 
 				// Transform the physical point back to input image space

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -22,6 +22,7 @@ func TestLinearInterpolator(t *testing.T) {
 		Spacing:   []float64{0.5, 0.5},
 		Origin:    []float64{0.25, 0.25},
 		Direction: [9]float64{1, 0, 0, 0, 1, 0, 0, 0, 1},
+		FillType:  FillTypeNearest,
 	}
 	newImg, err := img.Resample(interpolator)
 	if err != nil {
@@ -61,6 +62,7 @@ func TestLinearInterpolator2(t *testing.T) {
 		Spacing:   []float64{3.0 / 5.0, 3.0 / 5.0},
 		Origin:    []float64{3.0 / 5.0 / 2, 3.0 / 5.0 / 2},
 		Direction: [9]float64{1, 0, 0, 0, 1, 0, 0, 0, 1},
+		FillType:  FillTypeNearest,
 	}
 	newImg, err := img.Resample(interpolator)
 	if err != nil {
@@ -80,6 +82,58 @@ func TestLinearInterpolator2(t *testing.T) {
 	expected := float32(1)
 	if pixelValue != expected {
 		t.Errorf("Expected pixel value to be %v, got %v", expected, pixelValue)
+	}
+
+}
+
+func TestLinearInterpolator3(t *testing.T) {
+	pixelData := [][]float32{
+		{0, 0, 0, 0},
+		{0, 0, 0, 0},
+		{1, 1, 1, 1},
+		{1, 1, 1, 1},
+	}
+	img, err := GetImageFromArray(pixelData)
+	if err != nil {
+		t.Errorf("Error creating image from array: %v", err)
+	}
+	img.SetOrigin([]float64{0.5, 0.5})
+
+	interpolator := LinearInterpolator{
+		Size:      []uint32{4, 4},
+		Spacing:   []float64{1, 1},
+		Origin:    []float64{0.5, 3.5},
+		Direction: [9]float64{1, 0, 0, 0, -1, 0, 0, 0, 1},
+		FillType:  FillTypeNearest,
+	}
+	newImg, err := img.Resample(interpolator)
+	if err != nil {
+		t.Errorf("Error resampling image: %v", err)
+	}
+
+	size := newImg.GetSize()
+	if size[0] != 4 || size[1] != 4 {
+		t.Errorf("Expected size to be [4, 4], got %v", size)
+	}
+
+	expected := [][]float32{
+		{1, 1, 1, 1},
+		{1, 1, 1, 1},
+		{0, 0, 0, 0},
+		{0, 0, 0, 0},
+	}
+
+	for y := 0; y < 4; y++ {
+		for x := 0; x < 4; x++ {
+			pixelValue, err := newImg.GetPixelAsFloat32([]uint32{uint32(x), uint32(y)})
+			if err != nil {
+				t.Errorf("Error getting pixel value: %v", err)
+			}
+
+			if pixelValue != expected[y][x] {
+				t.Errorf("Expected pixel value to be %v, got %v", expected[y][x], pixelValue)
+			}
+		}
 	}
 
 }

--- a/stats.go
+++ b/stats.go
@@ -768,7 +768,7 @@ func (img *Image) Percentile(p float64) float64 {
 
 // OtsuThreshold returns the threshold value for the Otsu thresholding method.
 // Returns:
-// - float64: The threshold value.
+//   - float64: The threshold value.
 func (img *Image) OtsuThreshold() float64 {
 	var maxVal float64
 	switch img.pixelType {


### PR DESCRIPTION
This pull request includes several changes to improve the image manipulation and interpolation functionality in the codebase. The most important changes include adding a new package comment, updating the resampling logic in the `linearResample` and `nearestResample` functions, and enhancing the test coverage for the `LinearInterpolator`.

### Improvements to image manipulation:

* [`image.go`](diffhunk://#diff-f08e632d0e39faade2836cf30a8dfdeda63691486a5a33c2abd05b23d5a878c1R1): Added a package comment to provide an overview of the `image` package.

### Enhancements to interpolation logic:

* [`interpolate.go`](diffhunk://#diff-06a81cf280e7e45c951e1d5b98a5473d88b79230e7d8bd50a679d536485cd572R108-R120): Updated the `linearResample` function to include a new `indices` array and modified the calculation of the `point` array to use the `Direction` matrix for more accurate resampling.
* [`interpolate.go`](diffhunk://#diff-06a81cf280e7e45c951e1d5b98a5473d88b79230e7d8bd50a679d536485cd572R207-R219): Updated the `nearestResample` function similarly to the `linearResample` function, adding the `indices` array and modifying the `point` array calculation for improved accuracy.

### Test coverage improvements:

* [`interpolate_test.go`](diffhunk://#diff-d8e59ad4e52a3e9a051982da2b17189cf0a8e99ce6fcab2518dcaa19f8cfce5aR25): Added the `FillType` field to the `LinearInterpolator` initialization in the `TestLinearInterpolator` and `TestLinearInterpolator2` tests. [[1]](diffhunk://#diff-d8e59ad4e52a3e9a051982da2b17189cf0a8e99ce6fcab2518dcaa19f8cfce5aR25) [[2]](diffhunk://#diff-d8e59ad4e52a3e9a051982da2b17189cf0a8e99ce6fcab2518dcaa19f8cfce5aR65)
* [`interpolate_test.go`](diffhunk://#diff-d8e59ad4e52a3e9a051982da2b17189cf0a8e99ce6fcab2518dcaa19f8cfce5aR89-R140): Added a new test function `TestLinearInterpolator3` to further test the `LinearInterpolator` with different image data and parameters.